### PR TITLE
カレンダーを作る

### DIFF
--- a/python/my_calendar.py
+++ b/python/my_calendar.py
@@ -32,8 +32,8 @@ def get_last_date(year, month):
 # 現在日付(yyyy-mm-dd)
 d_today = datetime.date.today()
 
-# 曜日用のリスト
-day_of_week = ["月", "火", "水", "木", "金", "土", "日"]
+# 曜日表示用のリスト
+days_of_week = ["月", "火", "水", "木", "金", "土", "日"]
 
 # 月初日と月末日
 d_first = get_first_date(d_today.year, d_today.month)
@@ -46,15 +46,17 @@ calendar_list = []
 for _ in range(d_first.weekday()):
     calendar_list.append("   ")
 
-# 日付を追加
+# 日付を追加（1桁か2桁かで空白を考慮する）
 for day in range(1, d_last.day+1):
     if day <= 9:
         calendar_list.append(f" {day} ")
     else:
         calendar_list.append(f"{day} ")
 
+
 # カレンダー出力
 print(f"       {d_today.month}月 {d_today.year}")
-print(" ".join(day_of_week))
+print(" ".join(days_of_week))
+
 for i in range(0, len(calendar_list), 7):
     print("".join(calendar_list[i:i+7]))

--- a/python/my_calendar.py
+++ b/python/my_calendar.py
@@ -1,0 +1,60 @@
+import datetime
+
+
+def get_first_date(year, month):
+    """
+    月初日を取得する
+    :param year:年
+    :param month:月
+    :return:月初日
+    """
+    return datetime.date(year, month, 1)
+
+
+def get_last_date(year, month):
+    """
+    月末日を取得する
+    :param year:年
+    :param month:月
+    :return:月末日
+    """
+    # 翌月の月初日を取得
+    if month == 12:
+        next_month_first_date = datetime.date(year+1, 1, 1)
+    else:
+        next_month_first_date = datetime.date(year, month+1, 1)
+
+    # 翌月の月初日から1日引く
+    last_date = next_month_first_date - datetime.timedelta(days=1)
+    return last_date
+
+
+# 現在日付(yyyy-mm-dd)
+d_today = datetime.date.today()
+
+# 曜日用のリスト
+day_of_week = ["月", "火", "水", "木", "金", "土", "日"]
+
+# 月初日と月末日
+d_first = get_first_date(d_today.year, d_today.month)
+d_last = get_last_date(d_today.year, d_today.month)
+
+# 日付格納用のリスト
+calendar_list = []
+
+# 最初の週の空白を追加
+for _ in range(d_first.weekday()):
+    calendar_list.append("   ")
+
+# 日付を追加
+for day in range(1, d_last.day+1):
+    if day <= 9:
+        calendar_list.append(f" {day} ")
+    else:
+        calendar_list.append(f"{day} ")
+
+# カレンダー出力
+print(f"       {d_today.month}月 {d_today.year}")
+print(" ".join(day_of_week))
+for i in range(0, len(calendar_list), 7):
+    print("".join(calendar_list[i:i+7]))

--- a/python/my_calendar.py
+++ b/python/my_calendar.py
@@ -48,7 +48,7 @@ def main():
         except ValueError:
             sys.exit(f"{int(args[2])} is neither a month number (1..12) nor a name")
 
-        d_today = datetime.date(year=d_today.year, month=int(args[2]), day=1)
+        d_today = datetime.date(year=d_today.year, month=month, day=1)
     else:
         sys.exit("月を指定する場合は、コマンドライン引数を2つ入力してください。\n第1引数は -m 、第2引数は1〜12までの数値です。")
 
@@ -62,9 +62,9 @@ def main():
     # 日付格納用のリスト
     calendar_list = []
 
-    # 最初の週の空白を追加
+    # 最初の週の空白(半角スペース3個分)を追加
     for _ in range(d_first.weekday()):
-        calendar_list.append("   ")
+        calendar_list.append(" "*3)
 
     # 日付を追加（1桁か2桁かで空白を考慮する）
     for day in range(1, d_last.day+1):

--- a/python/my_calendar.py
+++ b/python/my_calendar.py
@@ -1,4 +1,5 @@
 import datetime
+import sys
 
 
 def get_first_date(year, month):
@@ -29,34 +30,55 @@ def get_last_date(year, month):
     return last_date
 
 
-# 現在日付(yyyy-mm-dd)
-d_today = datetime.date.today()
+def main():
+    # 現在日付(yyyy-mm-dd)
+    d_today = datetime.date.today()
 
-# 曜日表示用のリスト
-days_of_week = ["月", "火", "水", "木", "金", "土", "日"]
+    # コマンドライン引数のチェック
+    args = sys.argv
+    if len(args) == 1:
+        pass
+    elif len(args) == 3:
+        if args[1] != "-m":
+            sys.exit("第1引数は -m を入力してください。")
+        try:
+            month = int(args[2])
+            if month not in range(1, 13):
+                raise ValueError
+        except ValueError:
+            sys.exit(f"{int(args[2])} is neither a month number (1..12) nor a name")
 
-# 月初日と月末日
-d_first = get_first_date(d_today.year, d_today.month)
-d_last = get_last_date(d_today.year, d_today.month)
-
-# 日付格納用のリスト
-calendar_list = []
-
-# 最初の週の空白を追加
-for _ in range(d_first.weekday()):
-    calendar_list.append("   ")
-
-# 日付を追加（1桁か2桁かで空白を考慮する）
-for day in range(1, d_last.day+1):
-    if day <= 9:
-        calendar_list.append(f" {day} ")
+        d_today = datetime.date(year=d_today.year, month=int(args[2]), day=1)
     else:
-        calendar_list.append(f"{day} ")
+        sys.exit("月を指定する場合は、コマンドライン引数を2つ入力してください。\n第1引数は -m 、第2引数は1〜12までの数値です。")
+
+    # 曜日表示用のリスト
+    days_of_week = ["月", "火", "水", "木", "金", "土", "日"]
+
+    # 月初日と月末日
+    d_first = get_first_date(d_today.year, d_today.month)
+    d_last = get_last_date(d_today.year, d_today.month)
+
+    # 日付格納用のリスト
+    calendar_list = []
+
+    # 最初の週の空白を追加
+    for _ in range(d_first.weekday()):
+        calendar_list.append("   ")
+
+    # 日付を追加（1桁か2桁かで空白を考慮する）
+    for day in range(1, d_last.day+1):
+        if day <= 9:
+            calendar_list.append(f" {day} ")
+        else:
+            calendar_list.append(f"{day} ")
+
+    # カレンダー出力
+    print(f"       {d_today.month}月 {d_today.year}")
+    print(" ".join(days_of_week))
+    for i in range(0, len(calendar_list), 7):
+        print("".join(calendar_list[i:i+7]))
 
 
-# カレンダー出力
-print(f"       {d_today.month}月 {d_today.year}")
-print(" ".join(days_of_week))
-
-for i in range(0, len(calendar_list), 7):
-    print("".join(calendar_list[i:i+7]))
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 課題のリンク

- https://kirara-code.net/tasks/105

## やったこと

- ターミナル上にカレンダーを出力する処理作成
- カレンダーの仕様は以下の通りです。
  -  Python標準モジュールの`datatime`, `sys`のみ使用する。
  - `-m`オプションで月を指定できるようにして、指定月・今年のカレンダーを表示する。
  - `-m`オプションを指定しない場合、今月･今年のカレンダーを表示する。
  - `-m`の引数が不正な場合は下記エラーを出力する。
      ```
      python calendar.py -m 22
      22 is neither a month number (1..12) nor a name
      ```

## 動作確認方法
### -m オプションを指定しない場合

![CleanShot 2024-06-08 at 12 23 00@2x](https://github.com/otaki0413/hc_practice/assets/67969654/2e52bdda-84e4-40f9-8e91-4c9ba9e855cb)

### -m オプションで正常な月を指定する場合

![CleanShot 2024-06-08 at 12 24 33@2x](https://github.com/otaki0413/hc_practice/assets/67969654/482efacf-eeb9-44c6-8e0b-43e892e85368)

### -m オプションで不正な月を指定する場合
![CleanShot 2024-06-08 at 12 26 22@2x](https://github.com/otaki0413/hc_practice/assets/67969654/f2241427-bd44-4398-89d2-2b1ffc740cd5)



## その他
課題にはスクリプト名を`calendar.py`で作るように書かれていましたが、Pythonの`calendar`モジュール名と競合を起こしていたので、スクリプト名`my_calendar.py`に変更しております。
